### PR TITLE
Update README.md with warning about the MK4S

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -5,4 +5,4 @@
 Use at your own risk. I have not necessarily tested each individual file.
 If possible, use provided configs to compile your own hex files.
 
-If you have an MK4S, the firmware needs to be 6.2.0-RC1 or newer or you will get the BSOD. https://github.com/prusa3d/Prusa-Firmware-Buddy/releases/tag/v6.2.0-RC1
+If you are getting the BSOD ("Multile Errors CFSR" message) on the MK4S, upgrading to firmware 6.2.0-RC1 or newer may solve these issues. https://github.com/prusa3d/Prusa-Firmware-Buddy/releases/tag/v6.2.0-RC1

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -4,3 +4,5 @@
 
 Use at your own risk. I have not necessarily tested each individual file.
 If possible, use provided configs to compile your own hex files.
+
+If you have an MK4S, the firmware needs to be 6.2.0-RC1 or newer or you will get the BSOD. https://github.com/prusa3d/Prusa-Firmware-Buddy/releases/tag/v6.2.0-RC1


### PR DESCRIPTION
Warns that the MK4S needs to be at least firmware version 6.2.0-RC1 or you will get the BSOD. As I was the second one to run into this issue, I thought it would be helpful to have this added to the README.md